### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ let someNames = filterp(names) { $0 != "Peter" } // Promise<[String]>
 
 # Get started
 
-You can add Forbind to your project using [Cocoapods](https://cocoapods.org). Just add it to your Podfile:
+You can add Forbind to your project using [CocoaPods](https://cocoapods.org). Just add it to your Podfile:
 
 ```ruby
 use_frameworks!
@@ -64,7 +64,7 @@ pod 'Forbind', '~> 1.1'
 pod 'ForbindExtensions', :git => 'https://github.com/ulrikdamm/Forbind'
 ```
 
-(You need the ```use_frameworks!``` since that feature of Cocoapods is still in beta. ForbindExtensions are optional)
+(You need the ```use_frameworks!``` since that feature of CocoaPods is still in beta. ForbindExtensions are optional)
 
 Or you can add it using [Carthage](https://github.com/Carthage/Carthage) by adding this to your cartfile:
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
